### PR TITLE
fix: invalid bash default value syntax for API_SERVER in server.sh

### DIFF
--- a/v1/server/server.sh
+++ b/v1/server/server.sh
@@ -10,7 +10,7 @@ cat > env-config.js <<EOF
 // ce script est exécuté avant le main.js de ton app
 window.localStorage.setItem("custom-rendezvous-server", "${CUSTOM_RENDEZVOUS_SERVER:-}");
 window.localStorage.setItem("relay-server",             "${RELAY_SERVER:-}");
-window.localStorage.setItem("api-server",               "${API_SERVER:api.rustdesk.com}");
+window.localStorage.setItem("api-server",               "${API_SERVER:-api.rustdesk.com}");
 window.localStorage.setItem("key",                      "${KEY:-}");
 EOF
 


### PR DESCRIPTION
## Problem
`server.sh` uses `${API_SERVER:api.rustdesk.com}` which is invalid
bash syntax. When `API_SERVER` is set to a domain (e.g.
`rd.example.com`), bash tries to evaluate `api.rustdesk.com` as
an arithmetic offset for substring expansion, causing:

  syntax error: invalid arithmetic operator (error token is ".rustdesk.com")

## Fix
Replace `:` with `:-` — the correct bash syntax for parameter
default value substitution.

## Steps to reproduce
  docker run --rm -e API_SERVER=rd.example.com \
    pmietlicki/rustdesk-web-client:v1